### PR TITLE
Workaround to "remove" the last usage of ConfigureUtil.

### DIFF
--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/DefaultNexusRepositoryContainer.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/DefaultNexusRepositoryContainer.kt
@@ -20,6 +20,7 @@ import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.internal.NamedDomainObjectContainerConfigureDelegate
+import org.gradle.util.GradleVersion
 import java.net.URI
 import javax.inject.Inject
 
@@ -39,10 +40,28 @@ internal open class DefaultNexusRepositoryContainer @Inject constructor(
     }
 
     override fun configure(configureClosure: Closure<*>): NamedDomainObjectContainer<NexusRepository> =
-        @Suppress("DEPRECATION") // TODO https://github.com/gradle-nexus/publish-plugin/issues/152
-        org.gradle.util.ConfigureUtil.configureSelf(
-            configureClosure,
-            this,
-            NamedDomainObjectContainerConfigureDelegate(configureClosure, this)
-        )
+        if (GradleVersion.current() <= GradleVersion.version("7.6")) {
+            @Suppress("DEPRECATION")
+            // Keep using the old API on old Gradle versions.
+            // It was deprecated in Gradle 7.1, but only from Gradle 7.6 it emits a deprecation warning.
+            // https://docs.gradle.org/current/userguide/upgrading_version_7.html#org_gradle_util_reports_deprecations
+            // Note: this will fail to compile when this project starts building on Gradle 9.0,
+            // at which point, this will need to be fully resolved,
+            // OR this call for older support will need to be removed OR reflective.
+            org.gradle.util.ConfigureUtil.configureSelf(
+                configureClosure,
+                this,
+                NamedDomainObjectContainerConfigureDelegate(configureClosure, this)
+            )
+        } else {
+            // Keep using the new *internal* API on new Gradle versions.
+            // At least until https://github.com/gradle/gradle/issues/23874 is resolved.
+            // Introduced in Gradle 7.1, it's internal but stable up until the latest Gradle 8.0 at the time of writing.
+            // The Gradle 7.1 version of this class is a verbatim copy of Gradle 8.0's version, but without the nagging.
+            org.gradle.util.internal.ConfigureUtil.configureSelf(
+                configureClosure,
+                this,
+                NamedDomainObjectContainerConfigureDelegate(configureClosure, this)
+            )
+        }
 }


### PR DESCRIPTION
Needs Gradle 7.1 at the minimum, but would be best if gradle-nexus/publish-plugin#168 was merged first. Then I can rebase this and we can merge it. Alternatively we can just do the same with reflection, but I don't see a reason for keeping Gradle 6.9 for this project.